### PR TITLE
Avoid serving overview of main directory

### DIFF
--- a/main.go
+++ b/main.go
@@ -122,6 +122,10 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", contentType)
 	} else if r.Method == "GET" {
 		contentType := mime.TypeByExtension(filepath.Ext(fileStorePath))
+		if fileStorePath == "" {
+			http.Error(w, "403 Forbidden", 403)
+			return
+		}
 		if contentType == "" {
 			contentType = "application/octet-stream"
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -183,3 +183,26 @@ func TestDownloadGet(t *testing.T) {
 		t.Errorf("handler returned wrong status code: got %v want %v. HTTP body: %s", status, http.StatusOK, rr.Body.String())
 	}
 }
+
+func TestEmptyGet(t *testing.T) {
+	// Set config
+	readConfig("config.toml", &conf)
+
+	// Create request
+	req, err := http.NewRequest("GET", "", nil)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(handleRequest)
+
+	// Send request and record response
+	handler.ServeHTTP(rr, req)
+
+	// Check status code
+	if status := rr.Code; status != http.StatusForbidden {
+		t.Errorf("handler returned wrong status code: got %v want %v. HTTP body: %s", status, http.StatusForbidden, rr.Body.String())
+	}
+}


### PR DESCRIPTION
Thank you for this nice http upload server! I use it successfully in this [xmpp server distribution](http://github.com/xamanu/xmpp-server),

This pull requests blocks `GET` requests without any path to any file. Currently the full index of the directory is presented. However I would consider this an unwanted behaviour, because people don't want to have the whole list of all uploaded files available to the public.
