### PR TITLE
Let files be delivered by nginx directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ A simple file server for handling XMPP http_upload requests. This server is meat
 * Go is very good at serving HTTP requests.
 
 
-## Download 
+## Download
 
-If you are using regular x86_64 Linux, you can download a finished binary for your system on the [release page](https://github.com/ThomasLeister/prosody-filer/releases). **No need to compile this application yourself**. 
+If you are using regular x86_64 Linux, you can download a finished binary for your system on the [release page](https://github.com/ThomasLeister/prosody-filer/releases). **No need to compile this application yourself**.
 
 
 ## Build (optional)
@@ -32,15 +32,15 @@ If you're using something different than a x64 Linux, you need to compile this a
 
 To compile the server, you need a full Golang development environment. This can be set up quickly: https://golang.org/doc/install#install
 
-Then checkout this repo: 
+Then checkout this repo:
 
     go get github.com/ThomasLeister/prosody-filer
 
-and switch to the new directory: 
+and switch to the new directory:
 
     cd $GOPATH/src/github.com/ThomasLeister/prosody-filer
 
-The application can now be build: 
+The application can now be build:
 
     ### Build static binary
     ./build.sh
@@ -54,7 +54,7 @@ The application can now be build:
 
 ### Setup Prosody Filer environment
 
-Create a new user for Prosody Filer to run as: 
+Create a new user for Prosody Filer to run as:
 
     adduser --disabled-login --disabled-password prosody-filer
 
@@ -62,10 +62,10 @@ Switch to the new user:
 
     su - prosody-filer
 
-Copy  
+Copy
 
-* the binary ```prosody-filer``` and 
-* config ```config.example.toml``` 
+* the binary ```prosody-filer``` and
+* config ```config.example.toml```
 
 to ```/home/prosody-filer/```. Rename the configuration to ```config.toml```.
 
@@ -80,7 +80,7 @@ http_upload_external_secret = "mysecret"
 http_upload_external_file_size_limit = 50000000 -- 50 MB
 ```
 
-Restart Prosody when you are finished: 
+Restart Prosody when you are finished:
 
     systemctl restart prosody
 
@@ -96,13 +96,16 @@ listenport      = "127.0.0.1:5050"
 secret          = "mysecret"
 
 ### Where to store the uploaded files
-storeDir        = "./uploads/"
+storeDir        = "./upload/"
 
 ### Subdirectory for HTTP upload / download requests (usually "upload/")
 uploadSubDir    = "upload/"
 ```
 
 Make sure ```mysecret``` matches the secret defined in your mod_http_upload_external settings!
+
+In addition to that, the nginx user or group should be able to read the files in
+`/home/prosody-filer/upload/`.
 
 
 ### Systemd service file
@@ -118,12 +121,12 @@ Create a new Systemd service file: ```/etc/systemd/system/prosody-filer.service`
     Restart=always
     WorkingDirectory=/home/prosody-filer
     User=prosody-filer
-    Group=prosody-filer
+    Group=nginx
 
     [Install]
     WantedBy=multi-user.target
 
-Reload the service definitions, enable the service and start it: 
+Reload the service definitions, enable the service and start it:
 
     systemctl daemon-reload
     systemctl enable prosody-filer
@@ -148,15 +151,25 @@ Create a new config file ```/etc/nginx/sites-available/uploads.myserver.tld```:
         ssl_certificate /etc/letsencrypt/live/uploads.myserver.tld/fullchain.pem;
         ssl_certificate_key /etc/letsencrypt/live/uploads.myserver.tld/privkey.pem;
 
-        client_max_body_size 50m;
-
         location /upload/ {
-                proxy_pass http://127.0.0.1:5050/upload/;
-                proxy_request_buffering off;
+            root /home/prosody-filer;
+            client_max_body_size 51m;
+            client_body_buffer_size 51m;
+            try_files $uri $uri/ @prosodyfiler;
         }
-    }
 
-Enable the new config:  
+        location @prosodyfiler {
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host $host:$server_port;
+            proxy_set_header X-Forwarded-Server $host;
+            proxy_set_header X-Forwarded-For $remote_addr;
+            proxy_pass http://127.0.0.1:5050;
+            proxy_buffering off;
+        }
+
+Enable the new config:
 
     ln -s /etc/nginx/sites-available/uploads.myserver.tld /etc/nginx/sites-enabled/
 
@@ -174,9 +187,9 @@ Reload Nginx:
 
 Prosody Filer has no immediate knowlegde over all the stored files and the time they were uploaded, since no database exists for that. Also Prosody is not capable to do auto deletion if *mod_http_upload_external* is used. Therefore the suggested way of purging the uploads directory is to execute a purge command via a cron job:
 
-    @daily    find /home/prosody-filer/uploads -maxdepth 0 -type d -mtime +28 | xargs rm -rf
+    @daily    find /home/prosody-filer/upload -maxdepth 0 -type d -mtime +28 | xargs rm -rf
 
-This will delete uploads older than 28 days.  
+This will delete uploads older than 28 days.
 
 
 ## Check if it works
@@ -186,5 +199,3 @@ Get the log via
     journalctl -f -u prosody-filer
 
 If your XMPP clients uploads or downloads any file, there should be some log messages on the screen.
-
-


### PR DESCRIPTION
With these additional lines in the nginx config it should be possible to let nginx deliver the uploaded files directly.