### PR TITLE
Return status code 201 on PUT success

### DIFF
--- a/main.go
+++ b/main.go
@@ -113,6 +113,7 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 			}
 
 			log.Println("Successfully written", n, "bytes to file", fileStorePath)
+			w.WriteHeader(http.StatusCreated)
 		} else {
 			log.Println("Invalid MAC.")
 			http.Error(w, "403 Forbidden", 403)


### PR DESCRIPTION
XEP-0363 (version 0.9.0) [says][1]:

> An HTTP status code of 201 means that the server is now ready to serve the file via the provided GET URL.

Some clients assume the upload failed when receiving a status code of 200, so we now return 201 instead.

The commit is _completely untested_ (I don't use prosody-filer myself), sorry about that.  It's just meant to show the required behavior change.

[1]: https://xmpp.org/extensions/xep-0363.html#upload