### PR TITLE
Protect against shell-injection attacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ server {
 
 Prosody Filer has no immediate knowlegde over all the stored files and the time they were uploaded, since no database exists for that. Also Prosody is not capable to do auto deletion if *mod_http_upload_external* is used. Therefore the suggested way of purging the uploads directory is to execute a purge command via a cron job:
 
-    @daily    find /home/prosody-filer/upload/ -mindepth 1 -type d -mtime +28 | xargs rm -rf
+    @daily    find /home/prosody-filer/upload/ -mindepth 1 -type d -mtime +28 -print0 | xargs -0 -- rm -rf
 
 This will delete uploads older than 28 days.
 


### PR DESCRIPTION
By using `-print0`, filenames to purge are delimited by nuls instead of newlines, which can't be found in filenames on unix. Previously, someone who uploaded a file could inject an *extra set* of files to try to erase. For example, by uploading a file to:

"/path/to/dir/file1.png%09/var/log/messages%09/etc/passwd%09/home/user/something.png"

I can't take credit for this. This is from @horazont in https://github.com/horazont/xmpp-http-upload/issues/11#issuecomment-657131261