### PR TITLE
systemd activated sockets

### DIFF
--- a/deploy/prosody-filer.conf
+++ b/deploy/prosody-filer.conf
@@ -1,0 +1,3 @@
+# /usr/lib/sysusers.d/prosody-filer.conf
+#Type   Name        ID  GECOS                           Home dir                Shell
+u   prosody-filer   -   "Prosody file upload server"    /var/lib/prosody-filer

--- a/deploy/prosody-filer.nginx.conf
+++ b/deploy/prosody-filer.nginx.conf
@@ -1,0 +1,31 @@
+upstream prosody-filer {
+    server unix:/run/prosody-filer.sock;
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    server_name uploads.myserver.tld;
+
+    ssl_certificate /etc/letsencrypt/live/uploads.myserver.tld/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/uploads.myserver.tld/privkey.pem;
+
+    client_max_body_size 50m;
+
+    location /upload/ {
+        if ( $request_method = OPTIONS ) {
+            add_header Access-Control-Allow-Origin '*';
+            add_header Access-Control-Allow-Methods 'PUT, GET, OPTIONS, HEAD';
+            add_header Access-Control-Allow-Headers 'Authorization, Content-Type';
+            add_header Access-Control-Allow-Credentials 'true';
+            add_header Content-Length 0;
+            add_header Content-Type text/plain;
+            return 200;
+        }
+
+        proxy_pass http://prosody-filer;
+        proxy_request_buffering off;
+    }
+}

--- a/deploy/prosody-filer.service
+++ b/deploy/prosody-filer.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Prosody file upload server
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/prosody-filer
+Restart=on-failure
+WorkingDirectory=/var/lib/prosody-filer
+User=prosody-filer
+Group=prosody-filer
+# Group=nginx  # if the files should get served by nginx directly:
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/prosody-filer.socket
+++ b/deploy/prosody-filer.socket
@@ -1,0 +1,10 @@
+# see systemd.socket(5) for possible options
+[Socket]
+ListenStream=/var/run/prosody-filer.sock
+SocketMode=0660
+SocketUser=prosody-filer
+# if accessed by a reverse proxy, it has to be in this group
+SocketGroup=nginx
+
+[Install]
+WantedBy = sockets.target

--- a/prosody-filer.go
+++ b/prosody-filer.go
@@ -219,6 +219,7 @@ func main() {
 		for _, l := range listeners {
 			go func(listener net.Listener) {
 				log.Fatal(http.Serve(listener, nil))
+				wg.Done()
 			}(l)
 		}
 		wg.Wait()


### PR DESCRIPTION
[This](http://0pointer.de/blog/projects/socket-activated-containers.html) is a nice article explaining why systemd's socket activation feature is useful. I personally like it because I don't have to let services open any ports by themselves and I can put everything HTTP behind nginx with a unix socket as upstream, set up with proper permissions (note: nginx' group is www-data on some systems!) + I don't have to remember what's running on which port.

I haven't figured out yet how to make systemd-sysusers to create the user's home directory yet, but theoretically it's also supposed to simplify installation (see the files under `deploy/`):

```sh
# build
./build.sh
# install files (as root)
install prosody-filer /usr/local/bin/prosody-filer
install deploy/prosody-filer.service /usr/local/lib/systemd/system/prosody-filer.service
install deploy/prosody-filer.socket /usr/local/lib/systemd/system/prosody-filer.socket
install deploy/prosody-filer.conf /usr/lib/sysusers.d/prosody-filer.conf
install deploy/prosody-filer.nginx.conf /etc/nginx/sites-available/prosody-filer.nginx.conf
mkdir -p /var/lib/prosody-filer/uploads # or whatever directory is configured in the .service and .toml
install config.example.toml /var/lib/prosody-filer/config.toml
chown -R prosody-filer: /var/lib/prosody-filer

# create user and enable socket
systemd-sysusers
systemctl daemon-reload
systemctl enable prosody-filer.socket

# start socket, the service gets started automatically on the first incoming HTTP request
systemctl start prosody-filer.socket
```

It is theoretically even possible to provide the service with multiple sockets:
```
[Socket]
# unix socket
ListenStream=/var/run/prosody-filer.sock
# tcp port over ipv4 + ipv6 on all interfaces
ListenStream=8087
# listen on a specific localhost ipv4 address
ListenStream=127.0.23.42:12345
```

If prosody-filer is not given any systemd activated sockets, it will simply listen on the port given in the config, so this PR doesn't break compatibility.