### PR TITLE
Fix tests and make path handling more robust

### DIFF
--- a/prosody-filer.go
+++ b/prosody-filer.go
@@ -215,6 +215,7 @@ func main() {
 	 */
 	log.Println("Starting Prosody-Filer", versionString, "...")
 	subpath := path.Join("/", conf.UploadSubDir)
+	subpath += "/"
 	http.HandleFunc(subpath, handleRequest)
 	log.Printf("Server started on port %s. Waiting for requests.\n", conf.Listenport)
 	http.ListenAndServe(conf.Listenport, nil)

--- a/prosody-filer_test.go
+++ b/prosody-filer_test.go
@@ -20,14 +20,14 @@ import (
 )
 
 func mockUpload() {
-	os.MkdirAll(filepath.Dir(conf.Storedir+"thomas/abc/"), os.ModePerm)
+	os.MkdirAll(filepath.Join(conf.Storedir,"thomas/abc/"), os.ModePerm)
 	from, err := os.Open("./catmetal.jpg")
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer from.Close()
 
-	to, err := os.OpenFile(conf.Storedir+"thomas/abc/catmetal.jpg", os.O_RDWR|os.O_CREATE, 0660)
+	to, err := os.OpenFile(filepath.Join(conf.Storedir,"thomas/abc/catmetal.jpg"), os.O_RDWR|os.O_CREATE, 0660)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/prosody-filer_test.go
+++ b/prosody-filer_test.go
@@ -3,8 +3,8 @@ package main
 /*
  * Manual testing with CURL
  * Send with:
- * curl -X PUT "http://localhost:5050/upload/thomas/abc/catmetal.jpg?v=e17531b1e88bc9a5cbf816eca8a82fc09969c9245250f3e1b2e473bb564e4be0" --data-binary '@catmetal.jpg'
- * HMAC: e17531b1e88bc9a5cbf816eca8a82fc09969c9245250f3e1b2e473bb564e4be0
+ * curl -X PUT "http://localhost:5050/upload/thomas/abc/catmetal.jpg?v=7b8879e2d1c733b423a70cde30cecc3a3c64a03f790d1b5bcbb2a6aca52b477e" --data-binary '@catmetal.jpg'
+ * HMAC: 7b8879e2d1c733b423a70cde30cecc3a3c64a03f790d1b5bcbb2a6aca52b477e
  */
 
 import (
@@ -71,7 +71,7 @@ func TestUploadValid(t *testing.T) {
 	// Create request
 	req, err := http.NewRequest("PUT", "/upload/thomas/abc/catmetal.jpg", bytes.NewBuffer(catmetalfile))
 	q := req.URL.Query()
-	q.Add("v", "e17531b1e88bc9a5cbf816eca8a82fc09969c9245250f3e1b2e473bb564e4be0")
+	q.Add("v", "7b8879e2d1c733b423a70cde30cecc3a3c64a03f790d1b5bcbb2a6aca52b477e")
 	req.URL.RawQuery = q.Encode()
 
 	if err != nil {
@@ -85,7 +85,7 @@ func TestUploadValid(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	// Check status code
-	if status := rr.Code; status != http.StatusOK {
+	if status := rr.Code; status != http.StatusCreated {
 		t.Errorf("handler returned wrong status code: got %v want %v. HTTP body: %s", status, http.StatusOK, rr.Body.String())
 	}
 


### PR DESCRIPTION
These commits make the tests work again, and use the `path` and `path/filepath` libraries for path manipulation. This means the file data path doesn't need to have a trailing slash in order to work correctly, and that the upload sub directory can be given as an absolute path with a leading slash. Further details are in the commit messages.