### PR TITLE
Fix double slash when using / as handler

### DIFF
--- a/prosody-filer.go
+++ b/prosody-filer.go
@@ -38,6 +38,7 @@ type Config struct {
 
 var conf Config
 var versionString string = "0.0.0"
+
 const ALLOWED_METHODS string = "OPTIONS, HEAD, GET, PUT"
 
 /*
@@ -217,6 +218,7 @@ func main() {
 	 */
 	log.Println("Starting Prosody-Filer", versionString, "...")
 	subpath := path.Join("/", conf.UploadSubDir)
+	subpath = strings.TrimRight(subpath, "/")
 	subpath += "/"
 	http.HandleFunc(subpath, handleRequest)
 	log.Printf("Server started on port %s. Waiting for requests.\n", conf.Listenport)


### PR DESCRIPTION
#23 apparently broke my config which has `uploadSubDir = "/"` by trying to set `//` as the handler path.
This PR simply trims all trailing slashes before appending one, though this issue really only occurs when `subpath == /`...