### PR TITLE
Add metronome and prosody v2 functionality

### DIFF
--- a/prosody-filer.go
+++ b/prosody-filer.go
@@ -122,7 +122,8 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
         
 		mac_v1.Write([]byte(fileStorePath + " " + strconv.FormatInt(r.ContentLength, 10)))
 		mac_v1_String := hex.EncodeToString(mac_v1.Sum(nil))
-        mac_v2.Write([]byte(fileStorePath + " " + strconv.FormatInt(r.ContentLength, 10) + " " + contentType))
+        // use a 0-code byte between strings by prosody v2 specification
+        mac_v2.Write([]byte(fileStorePath + "\x00" + strconv.FormatInt(r.ContentLength, 10) + "\x00" + contentType))
 		mac_v2_String := hex.EncodeToString(mac_v2.Sum(nil))
         fmt.Println("MAC sent: ", a["token"][0])
         fmt.Println("MAC v1  : ", mac_v1_String)

--- a/prosody-filer.go
+++ b/prosody-filer.go
@@ -115,7 +115,7 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 		log.Println("fileStorePath:", fileStorePath)
 		log.Println("ContentLength:", strconv.FormatInt(r.ContentLength, 10))
         log.Println("fileType:", contentType)
-		mac.Write([]byte(fileStorePath + " " + strconv.FormatInt(r.ContentLength, 10) + contentType))
+		mac.Write([]byte(fileStorePath + " " + strconv.FormatInt(r.ContentLength, 10)))
 		macString := hex.EncodeToString(mac.Sum(nil))
         fmt.Println("MAC sent: ", a["token"][0])
         fmt.Println("MAC gen : ", macString)

--- a/prosody-filer.go
+++ b/prosody-filer.go
@@ -145,6 +145,7 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 			return
 		} else {
 			log.Println("Invalid MAC.")
+            log.Println(macString, " is different than ", a["token"][0])
 			http.Error(w, "403 Forbidden", 403)
 			return
 		}

--- a/prosody-filer.go
+++ b/prosody-filer.go
@@ -118,7 +118,7 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 		mac.Write([]byte(fileStorePath + " " + strconv.FormatInt(r.ContentLength, 10) + contentType))
 		macString := hex.EncodeToString(mac.Sum(nil))
         fmt.Println("MAC sent: ", a["token"][0])
-        fmt.Println("MAC gen : ", []byte(macString))
+        fmt.Println("MAC gen : ", macString)
         
         /*
 		 * Check whether calculated (expected) MAC is the MAC that client send in "v" URL parameter
@@ -152,7 +152,11 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 			return
 		} else {
 			log.Println("Invalid MAC.")
-            //log.Println(macString, " is different than ", a["token"][0])
+            log.Println([]byte(macString), " is different than ", []byte(a["token"][0]))
+            log.Println([]byte(macString))
+            log.Println([]byte(a["token"][0]))
+
+
 			http.Error(w, "403 Forbidden", 403)
 			return
 		}

--- a/prosody-filer.go
+++ b/prosody-filer.go
@@ -102,7 +102,7 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		fmt.Println("MAC sent: ", a["token"][0])
+		//fmt.Println("MAC sent: ", a["token"][0])
 
 		/*
 		 * Check if the request is valid
@@ -117,6 +117,8 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
         log.Println("fileType:", contentType)
 		mac.Write([]byte(fileStorePath + " " + strconv.FormatInt(r.ContentLength, 10) + contentType))
 		macString := hex.EncodeToString(mac.Sum(nil))
+        fmt.Println("MAC sent: ", a["token"][0])
+        fmt.Println("MAC gen : ", []byte(macString))
         
         /*
 		 * Check whether calculated (expected) MAC is the MAC that client send in "v" URL parameter
@@ -150,7 +152,7 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 			return
 		} else {
 			log.Println("Invalid MAC.")
-            log.Println(macString, " is different than ", a["token"][0])
+            //log.Println(macString, " is different than ", a["token"][0])
 			http.Error(w, "403 Forbidden", 403)
 			return
 		}

--- a/prosody-filer.go
+++ b/prosody-filer.go
@@ -114,6 +114,7 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 		mac := hmac.New(sha256.New, []byte(conf.Secret))
 		log.Println("fileStorePath:", fileStorePath)
 		log.Println("ContentLength:", strconv.FormatInt(r.ContentLength, 10))
+        log.Println("fileType:", contentType)
 		mac.Write([]byte(fileStorePath + " " + strconv.FormatInt(r.ContentLength, 10) + contentType))
 		macString := hex.EncodeToString(mac.Sum(nil))
         

--- a/prosody-filer.go
+++ b/prosody-filer.go
@@ -93,14 +93,22 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 
 	// Add CORS headers
 	addCORSheaders(w)
-
+    
 	if r.Method == http.MethodPut {
 		// Check if MAC is attached to URL
-		if a["token"] == nil {
-			log.Println("Error: No HMAC attached to URL.")
+        // Default protocol_version
+        var protocol_version string
+		if a["token"] != nil {
+            protocol_version = "token"
+		} else if a["v"] != nil {
+            protocol_version = "v"
+        } else if a["v2"] != nil {
+            protocol_version = "v2"
+        } else {
+            log.Println("Error: No HMAC attached to URL. Expected URL with v, v2 or token")
 			http.Error(w, "409 Conflict", 409)
-			return
-		}
+            return
+        }
 
 		//fmt.Println("MAC sent: ", a["token"][0])
 
@@ -119,20 +127,20 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 		log.Println("fileStorePath:", fileStorePath)
 		log.Println("ContentLength:", strconv.FormatInt(r.ContentLength, 10))
         log.Println("fileType:", contentType)
-        
+        log.Println("Protocol version used:", protocol_version)
 		mac_v1.Write([]byte(fileStorePath + " " + strconv.FormatInt(r.ContentLength, 10)))
 		mac_v1_String := hex.EncodeToString(mac_v1.Sum(nil))
         // use a 0-code byte between strings by prosody v2 specification
         mac_v2.Write([]byte(fileStorePath + "\x00" + strconv.FormatInt(r.ContentLength, 10) + "\x00" + contentType))
 		mac_v2_String := hex.EncodeToString(mac_v2.Sum(nil))
-        fmt.Println("MAC sent: ", a["token"][0])
+        fmt.Println("MAC sent: ", a[protocol_version][0])
         fmt.Println("MAC v1  : ", mac_v1_String)
         fmt.Println("MAC v2  : ", mac_v2_String)
         
         /*
 		 * Check whether calculated (expected) MAC is the MAC that client send in "v" URL parameter
 		 */
-		if hmac.Equal([]byte(mac_v1_String), []byte(a["token"][0])) {
+		if hmac.Equal([]byte(mac_v1_String), []byte(a[protocol_version][0])) {
 			// Make sure the path exists
 			err := os.MkdirAll(filepath.Dir(absFilename), os.ModePerm)
 			if err != nil {
@@ -159,7 +167,7 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 			log.Println("Successfully written", n, "bytes to file", fileStorePath)
 			w.WriteHeader(http.StatusCreated)
 			return
-		} else if hmac.Equal([]byte(mac_v2_String), []byte(a["token"][0])) {
+		} else if hmac.Equal([]byte(mac_v2_String), []byte(a[protocol_version][0])) {
 			// Make sure the path exists
 			err := os.MkdirAll(filepath.Dir(absFilename), os.ModePerm)
 			if err != nil {
@@ -190,7 +198,7 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 			log.Println("Invalid MAC:")
             log.Println([]byte(mac_v1_String))
             log.Println([]byte(mac_v2_String))
-            log.Println([]byte(a["token"][0]))
+            log.Println([]byte(a[protocol_version][0]))
 			http.Error(w, "403 Forbidden", 403)
 			return
 		}
@@ -211,7 +219,7 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 		 * MIME content type, but this does not work with encrypted files (=> OMEMO). Therefore we're just
 		 * relying on file extensions.
 		 */
-		contentType := mime.TypeByExtension(filepath.Ext(fileStorePath))
+        contentType := mime.TypeByExtension(filepath.Ext(fileStorePath))
 		if contentType == "" {
 			contentType = "application/octet-stream"
 		}

--- a/prosody-filer.go
+++ b/prosody-filer.go
@@ -42,13 +42,13 @@ var conf Config
 var versionString string = "0.0.0"
 
 var ALLOWED_METHODS string = strings.Join(
-    []string{
-        http.MethodOptions,
-        http.MethodHead,
-        http.MethodGet,
-        http.MethodPut,
-    },
-    ", ",
+	[]string{
+		http.MethodOptions,
+		http.MethodHead,
+		http.MethodGet,
+		http.MethodPut,
+	},
+	", ",
 )
 
 /*
@@ -93,54 +93,54 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 
 	// Add CORS headers
 	addCORSheaders(w)
-    
+
 	if r.Method == http.MethodPut {
 		// Check if MAC is attached to URL
-        // Default protocol_version
-        var protocol_version string
+		// Default protocol_version
+		var protocol_version string
 		if a["token"] != nil {
-            protocol_version = "token"
+			protocol_version = "token"
 		} else if a["v"] != nil {
-            protocol_version = "v"
-        } else if a["v2"] != nil {
-            protocol_version = "v2"
-        } else {
-            log.Println("Error: No HMAC attached to URL. Expected URL with v, v2 or token")
+			protocol_version = "v"
+		} else if a["v2"] != nil {
+			protocol_version = "v2"
+		} else {
+			log.Println("Error: No HMAC attached to URL. Expected URL with v, v2 or token")
 			http.Error(w, "409 Conflict", 409)
-            return
-        }
+			return
+		}
 
 		//fmt.Println("MAC sent: ", a["token"][0])
 
 		/*
 		 * Check if the request is valid
 		 */
-        
-        contentType := mime.TypeByExtension(filepath.Ext(fileStorePath))
+
+		contentType := mime.TypeByExtension(filepath.Ext(fileStorePath))
 		if contentType == "" {
 			contentType = "application/octet-stream"
 		}
-		
+
 		mac_v1 := hmac.New(sha256.New, []byte(conf.Secret))
-        mac_v2 := hmac.New(sha256.New, []byte(conf.Secret))
-        
-        //log info + MAC key generation
+		mac_v2 := hmac.New(sha256.New, []byte(conf.Secret))
+
+		//log info + MAC key generation
 		log.Println("fileStorePath:", fileStorePath)
 		log.Println("ContentLength:", strconv.FormatInt(r.ContentLength, 10))
-        log.Println("fileType:", contentType)
-        log.Println("Protocol version used:", protocol_version)
+		log.Println("fileType:", contentType)
+		log.Println("Protocol version used:", protocol_version)
 		mac_v1.Write([]byte(fileStorePath + " " + strconv.FormatInt(r.ContentLength, 10)))
 		mac_v1_String := hex.EncodeToString(mac_v1.Sum(nil))
-        // use a 0-code byte between strings by prosody v2 specification
-        mac_v2.Write([]byte(fileStorePath + "\x00" + strconv.FormatInt(r.ContentLength, 10) + "\x00" + contentType))
+		// use a 0-code byte between strings by prosody v2 specification
+		mac_v2.Write([]byte(fileStorePath + "\x00" + strconv.FormatInt(r.ContentLength, 10) + "\x00" + contentType))
 		mac_v2_String := hex.EncodeToString(mac_v2.Sum(nil))
-        fmt.Println("MAC sent: ", a[protocol_version][0])
-        
-        //Debug logging
-        //fmt.Println("MAC v1  : ", mac_v1_String)
-        //fmt.Println("MAC v2  : ", mac_v2_String)
-        
-        /*
+		fmt.Println("MAC sent: ", a[protocol_version][0])
+
+		//Debug logging
+		//fmt.Println("MAC v1  : ", mac_v1_String)
+		//fmt.Println("MAC v2  : ", mac_v2_String)
+
+		/*
 		 * Check whether calculated (expected) MAC is the MAC that client send in "v" URL parameter
 		 */
 		if hmac.Equal([]byte(mac_v1_String), []byte(a[protocol_version][0])) {
@@ -199,10 +199,10 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 			return
 		} else {
 			log.Println("Invalid MAC")
-            //Debug - log byte comparision
-            //log.Println([]byte(mac_v1_String))
-            //log.Println([]byte(mac_v2_String))
-            //log.Println([]byte(a[protocol_version][0]))
+			//Debug - log byte comparision
+			//log.Println([]byte(mac_v1_String))
+			//log.Println([]byte(mac_v2_String))
+			//log.Println([]byte(a[protocol_version][0]))
 			http.Error(w, "403 Forbidden", 403)
 			return
 		}
@@ -223,7 +223,7 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 		 * MIME content type, but this does not work with encrypted files (=> OMEMO). Therefore we're just
 		 * relying on file extensions.
 		 */
-        contentType := mime.TypeByExtension(filepath.Ext(fileStorePath))
+		contentType := mime.TypeByExtension(filepath.Ext(fileStorePath))
 		if contentType == "" {
 			contentType = "application/octet-stream"
 		}
@@ -279,7 +279,6 @@ func main() {
 	if !flag.Parsed() {
 		log.Fatalln("Could not parse flags")
 	}
-
 
 	/*
 	 * Read config file

--- a/prosody-filer.go
+++ b/prosody-filer.go
@@ -122,7 +122,7 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
         
 		mac_v1.Write([]byte(fileStorePath + " " + strconv.FormatInt(r.ContentLength, 10)))
 		mac_v1_String := hex.EncodeToString(mac_v1.Sum(nil))
-        mac_v2.Write([]byte(fileStorePath + " " + strconv.FormatInt(r.ContentLength, 10) + contentType))
+        mac_v2.Write([]byte(fileStorePath + " " + strconv.FormatInt(r.ContentLength, 10) + " " + contentType))
 		mac_v2_String := hex.EncodeToString(mac_v2.Sum(nil))
         fmt.Println("MAC sent: ", a["token"][0])
         fmt.Println("MAC v1  : ", mac_v1_String)

--- a/prosody-filer.go
+++ b/prosody-filer.go
@@ -102,7 +102,7 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		fmt.Println("MAC sent: ", a["v"][0])
+		fmt.Println("MAC sent: ", a["token"][0])
 
 		/*
 		 * Check if the request is valid
@@ -116,7 +116,7 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 		/*
 		 * Check whether calculated (expected) MAC is the MAC that client send in "v" URL parameter
 		 */
-		if hmac.Equal([]byte(macString), []byte(a["v"][0])) {
+		if hmac.Equal([]byte(macString), []byte(a["token"][0])) {
 			// Make sure the path exists
 			err := os.MkdirAll(filepath.Dir(absFilename), os.ModePerm)
 			if err != nil {

--- a/prosody-filer.go
+++ b/prosody-filer.go
@@ -107,13 +107,17 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 		/*
 		 * Check if the request is valid
 		 */
+        contentType := mime.TypeByExtension(filepath.Ext(fileStorePath))
+		if contentType == "" {
+			contentType = "application/octet-stream"
+		}
 		mac := hmac.New(sha256.New, []byte(conf.Secret))
 		log.Println("fileStorePath:", fileStorePath)
 		log.Println("ContentLength:", strconv.FormatInt(r.ContentLength, 10))
-		mac.Write([]byte(fileStorePath + " " + strconv.FormatInt(r.ContentLength, 10)))
+		mac.Write([]byte(fileStorePath + " " + strconv.FormatInt(r.ContentLength, 10) + contentType))
 		macString := hex.EncodeToString(mac.Sum(nil))
-
-		/*
+        
+        /*
 		 * Check whether calculated (expected) MAC is the MAC that client send in "v" URL parameter
 		 */
 		if hmac.Equal([]byte(macString), []byte(a["token"][0])) {

--- a/prosody-filer.go
+++ b/prosody-filer.go
@@ -124,6 +124,7 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 		mac_v1 := hmac.New(sha256.New, []byte(conf.Secret))
         mac_v2 := hmac.New(sha256.New, []byte(conf.Secret))
         
+        //log info + MAC key generation
 		log.Println("fileStorePath:", fileStorePath)
 		log.Println("ContentLength:", strconv.FormatInt(r.ContentLength, 10))
         log.Println("fileType:", contentType)
@@ -134,8 +135,10 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
         mac_v2.Write([]byte(fileStorePath + "\x00" + strconv.FormatInt(r.ContentLength, 10) + "\x00" + contentType))
 		mac_v2_String := hex.EncodeToString(mac_v2.Sum(nil))
         fmt.Println("MAC sent: ", a[protocol_version][0])
-        fmt.Println("MAC v1  : ", mac_v1_String)
-        fmt.Println("MAC v2  : ", mac_v2_String)
+        
+        //Debug logging
+        //fmt.Println("MAC v1  : ", mac_v1_String)
+        //fmt.Println("MAC v2  : ", mac_v2_String)
         
         /*
 		 * Check whether calculated (expected) MAC is the MAC that client send in "v" URL parameter
@@ -195,10 +198,11 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusCreated)
 			return
 		} else {
-			log.Println("Invalid MAC:")
-            log.Println([]byte(mac_v1_String))
-            log.Println([]byte(mac_v2_String))
-            log.Println([]byte(a[protocol_version][0]))
+			log.Println("Invalid MAC")
+            //Debug - log byte comparision
+            //log.Println([]byte(mac_v1_String))
+            //log.Println([]byte(mac_v2_String))
+            //log.Println([]byte(a[protocol_version][0]))
 			http.Error(w, "403 Forbidden", 403)
 			return
 		}

--- a/prosody-filer.go
+++ b/prosody-filer.go
@@ -96,7 +96,7 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 
 	if r.Method == http.MethodPut {
 		// Check if MAC is attached to URL
-		if a["v"] == nil {
+		if a["token"] == nil {
 			log.Println("Error: No HMAC attached to URL.")
 			http.Error(w, "409 Conflict", 409)
 			return

--- a/prosody-filer_test.go
+++ b/prosody-filer_test.go
@@ -71,7 +71,7 @@ func TestUploadValid(t *testing.T) {
 	// Create request
 	req, err := http.NewRequest("PUT", "/upload/thomas/abc/catmetal.jpg", bytes.NewBuffer(catmetalfile))
 	q := req.URL.Query()
-	q.Add("token", "7b8879e2d1c733b423a70cde30cecc3a3c64a03f790d1b5bcbb2a6aca52b477e")
+	q.Add("v", "7b8879e2d1c733b423a70cde30cecc3a3c64a03f790d1b5bcbb2a6aca52b477e")
 	req.URL.RawQuery = q.Encode()
 
 	if err != nil {
@@ -135,7 +135,7 @@ func TestUploadInvalidMAC(t *testing.T) {
 	// Create request
 	req, err := http.NewRequest("PUT", "/upload/thomas/abc/catmetal.jpg", bytes.NewBuffer(catmetalfile))
 	q := req.URL.Query()
-	q.Add("token", "abc")
+	q.Add("v", "abc")
 	req.URL.RawQuery = q.Encode()
 
 	if err != nil {

--- a/prosody-filer_test.go
+++ b/prosody-filer_test.go
@@ -71,7 +71,7 @@ func TestUploadValid(t *testing.T) {
 	// Create request
 	req, err := http.NewRequest("PUT", "/upload/thomas/abc/catmetal.jpg", bytes.NewBuffer(catmetalfile))
 	q := req.URL.Query()
-	q.Add("v", "7b8879e2d1c733b423a70cde30cecc3a3c64a03f790d1b5bcbb2a6aca52b477e")
+	q.Add("token", "7b8879e2d1c733b423a70cde30cecc3a3c64a03f790d1b5bcbb2a6aca52b477e")
 	req.URL.RawQuery = q.Encode()
 
 	if err != nil {
@@ -135,7 +135,7 @@ func TestUploadInvalidMAC(t *testing.T) {
 	// Create request
 	req, err := http.NewRequest("PUT", "/upload/thomas/abc/catmetal.jpg", bytes.NewBuffer(catmetalfile))
 	q := req.URL.Query()
-	q.Add("v", "abc")
+	q.Add("token", "abc")
 	req.URL.RawQuery = q.Encode()
 
 	if err != nil {


### PR DESCRIPTION
Here per prosody documentation of [http_upload_external](https://modules.prosody.im/mod_http_upload_external.html) I added the second version of their protocol which takes MIME types into consideration (this is compatible with a prosody fork, metronome which uses a modified version of v2 with the name of token).

I left commented some lines I used to debug and develop you may erase them if you want to keep the code clean.

Also the way I did it was a bit messy and could be done in a better way but it works.

Closes #29 and maybe #32.